### PR TITLE
Add 'dangerous' install target / Linux ZSH completion / README updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,13 @@ ifeq ($(OS),Windows_NT)
 	GIT_TAG := $(shell git describe --abbrev=0 --tags 2>/dev/null)
 	GOPRIVATE_OS_ENV_CMD := set GOPRIVATE="github.com/ivcap-works/ivcap-core-api" &&
 	EXTENSION := .exe
+	USER_SHELL := powershell
 else
 	BUILD_DATE := $(shell date "+%Y-%m-%dT%H:%M")
 	GIT_TAG := $(shell git describe --abbrev=0 --tags 2>/dev/null || true)
 	GOPRIVATE_OS_ENV_CMD := export GOPRIVATE="github.com/ivcap-works/ivcap-core-api" &&
+	USER_SHELL := $(shell echo $$(basename $$SHELL))
 endif
-
-UNAME := $(shell sh -c 'uname 2>/dev/null || echo Unknown')
-USER_SHELL := $(shell echo $$SHELL)
 
 MOVIE_SIZE=1280x720 # 640x360
 MOVIE_NAME=ivcap-cli.mp4
@@ -39,33 +38,13 @@ build-docs:
 	doc/create-docs
 	rm -f doc/create-docs
 
-ifeq ($(UNAME), Linux)
-completion: completion-linux
-else ifeq ($(UNAME), Darwin)
-completion: completion-mac
-else
 completion:
-	@echo "Unsupported operating system. Cannot add IVCAP completion."
-endif
-
-completion-mac:
-	@if [[ -d $(shell brew --prefix)/share/zsh/site-functions ]]; then \
-		echo "Adding completion for ZSH." ;\
-		$(shell go env GOBIN)/ivcap completion zsh > $(shell brew --prefix)/share/zsh/site-functions/_ivcap ;\
-	else \
-		echo "Unsupported macOS shell. Cannot add IVCAP completion." ;\
-	fi
-
-completion-linux:
-	@if [ "${USER_SHELL}" = "/usr/bin/zsh" ] && [[ -d "${HOME}/.zsh/" ]] ; then \
-		echo -e '\nAdding ZSH completions to "${HOME}/.zsh/site-functions".' ;\
-		mkdir -p "${HOME}/.zsh/site-functions/" ;\
-		$(shell go env GOPATH)/bin/ivcap completion zsh > "${HOME}/.zsh/site-functions/_ivcap" ;\
-		echo -e 'Please add "${HOME}/.zsh/site-functions" to your .zshrc config:\n' ;\
-		echo -e '    fpath=("$${HOME}/.zsh/site-functions" $$fpath).\n' ;\
-	else \
-		echo "Unsupported Linux shell. Cannot add IVCAP completion." ;\
-	fi
+	@case ${USER_SHELL} in \
+		bash) ivcap completion bash -h ;; \
+		zsh)  ivcap completion zsh  -h ;; \
+		fish) ivcap completion fish -h ;; \
+		powershell) ivcap completion powershell -h ;; \
+	esac
 
 clean:
 	rm ivcap

--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,17 @@ MOVIE_NAME=ivcap-cli.mp4
 
 LD_FLAGS="-X main.version=${GIT_TAG} -X main.commit=${GIT_COMMIT} -X main.date=${BUILD_DATE}"
 
-build: addlicense check build-docs
-	@echo "Building IVCAP-CLI..."
-	${GOPRIVATE_ENV_CMD} go mod tidy
-	go  build -ldflags ${LD_FLAGS} ivcap.go
+build: addlicense check build-docs build-dangerously
+
+install: addlicense check install-dangerously
 
 build-dangerously:
 	@echo "Building IVCAP-CLI..."
 	${GOPRIVATE_ENV_CMD} go mod tidy
 	go build -ldflags ${LD_FLAGS} ivcap.go
+
+install-dangerously:
+	go install -ldflags ${LD_FLAGS} ivcap.go
 
 build-docs:
 	go -C doc build -ldflags ${LD_FLAGS} create-docs.go
@@ -34,11 +36,6 @@ build-docs:
 	doc/create-docs
 	rm -f doc/create-docs
 
-install: addlicense check
-	go install -ldflags ${LD_FLAGS} ivcap.go
-	if [[ -d $(shell brew --prefix)/share/zsh/site-functions ]]; then \
-		$(shell go env GOBIN)/ivcap completion zsh > $(shell brew --prefix)/share/zsh/site-functions/_ivcap;\
-  fi
 
 clean:
 	rm ivcap

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GIT_COMMIT := $(shell git rev-list --abbrev-commit --tags --max-count=1)
 ifeq ($(OS),Windows_NT)
 	space := $(subst ,, )
 	BUILD_DATE := $(subst $(space),,$(strip $(shell date /T))-$(shell time /T))
-	GIT_TAG := $(shell git describe --abbrev=0 --tags 2> nul)
+	GIT_TAG := $(shell git describe --abbrev=0 --tags 2>/dev/null)
 	GOPRIVATE_OS_ENV_CMD := set GOPRIVATE="github.com/ivcap-works/ivcap-core-api" &&
 	EXTENSION := .exe
 else
@@ -23,7 +23,7 @@ LD_FLAGS="-X main.version=${GIT_TAG} -X main.commit=${GIT_COMMIT} -X main.date=$
 
 build: addlicense check build-docs build-dangerously
 
-install: addlicense check install-dangerously
+install: addlicense check install-dangerously completion
 
 build-dangerously:
 	@echo "Building IVCAP-CLI..."

--- a/README.md
+++ b/README.md
@@ -4,31 +4,12 @@ __IVCAP__ is helping researchers better investigate their domains and derive new
 
 __IVCAP__ has an extensive REST API which is usually called directly from applications or scientific notebooks. However, to support simple data operation from the command line, we developed this simple command-line tool. It only covers the subset of the IVCAP API, but we would be very excited to receive pull requests to extend it's functionality or fix bugs.
 
-## Developing
-
-### Prerequisites
-
-You will need the following installed:
-
-- go version >= 1.22.2 (e.g. `snap install go --classic`)
-- golangci-lint (e.g. `snap install golangci-lint`)
-- gocritic (e.g. `go install -v github.com/go-critic/go-critic/cmd/gocritic@latest`; you may also need to add `~/go/bin` to your `PATH`)
-- staticcheck (`go install honnef.co/go/tools/cmd/staticcheck@latest`)
-- gosec (`go install github.com/securego/gosec/v2/cmd/gosec@latest`)
-- govulncheck (`go install golang.org/x/vuln/cmd/govulncheck@latest`)
-- addlicense (`go install github.com/nokia/addlicense@latest`)
-
-### Build
-
-To build, ensure you have the prerequisites and then run `make`.
-
-### Install
-
-To install from the local development code, run `make install`. You should now have the `ivcap-cli` command available in your shell.
-
 ## Install
 
-There are [ready to use binaries](https://github.com/ivcap-works/ivcap-cli/releases/latest) for some architectures available at the repo's [release](https://github.com/ivcap-works/ivcap-cli/releases) tab.
+There are [ready to use
+binaries](https://github.com/ivcap-works/ivcap-cli/releases/latest) for some
+architectures available at the repo's
+[release](https://github.com/ivcap-works/ivcap-cli/releases) tab.
 
 If you use [homebrew](https://brew.sh/), you can install it by:
 
@@ -234,3 +215,40 @@ Successfully wrote 50855 bytes to /tmp/out.png
 ```
 
 Follow this [link](./doc/ivcap_artifact.md) for more details about the `artifact` command.
+
+
+## Development
+
+### Prerequisites
+
+You will need the following installed:
+
+- go version >= 1.22.2 (e.g. `snap install go --classic`)
+- golangci-lint (e.g. `snap install golangci-lint`)
+- gocritic (e.g. `go install -v github.com/go-critic/go-critic/cmd/gocritic@latest`; you may also need to add `~/go/bin` to your `PATH`)
+- staticcheck (`go install honnef.co/go/tools/cmd/staticcheck@latest`)
+- gosec (`go install github.com/securego/gosec/v2/cmd/gosec@latest`)
+- govulncheck (`go install golang.org/x/vuln/cmd/govulncheck@latest`)
+- addlicense (`go install github.com/nokia/addlicense@latest`)
+
+### Build & Install
+
+To build and install from local source code, ensure you have the prerequisites
+and run:
+
+```shell
+make build
+make install
+```
+
+If your Go paths are configured correctly, you should now have the `ivcap`
+command available in your shell.
+
+To build and install without performing any code checks (implicitly done via `make
+check`) run:
+
+
+```shell
+make build-dangerously
+make install-dangerously
+```

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ __IVCAP__ has an extensive REST API which is usually called directly from applic
 
 ## Install
 
-There are [ready to use
-binaries](https://github.com/ivcap-works/ivcap-cli/releases/latest) for some
-architectures available at the repo's
-[release](https://github.com/ivcap-works/ivcap-cli/releases) tab.
+[binary-releases]: https://github.com/ivcap-works/ivcap-cli/releases/latest
+[release-page]:    https://github.com/ivcap-works/ivcap-cli/releases
+
+There are [ready to use binaries][binary-releases] for some architectures available at the repo's [release][release-page] tab.
 
 If you use [homebrew](https://brew.sh/), you can install it by:
 
@@ -223,13 +223,20 @@ Follow this [link](./doc/ivcap_artifact.md) for more details about the `artifact
 
 You will need the following installed:
 
+[golangci-lint]: https://golangci-lint.run/welcome/install/#local-installation
+[gocritic]:      https://github.com/go-critic/go-critic?tab=readme-ov-file#installation
+[staticcheck]:   https://staticcheck.dev/docs/getting-started/#installation
+[gosec]:         https://github.com/securego/gosec?tab=readme-ov-file#install
+[govulncheck]:   https://go.googlesource.com/vuln
+[addlicense]:    https://github.com/nokia/addlicense?tab=readme-ov-file#install-as-a-go-program
+
 - go version >= 1.22.2 (e.g. `snap install go --classic`)
-- golangci-lint (e.g. `snap install golangci-lint`)
-- gocritic (e.g. `go install -v github.com/go-critic/go-critic/cmd/gocritic@latest`; you may also need to add `~/go/bin` to your `PATH`)
-- staticcheck (`go install honnef.co/go/tools/cmd/staticcheck@latest`)
-- gosec (`go install github.com/securego/gosec/v2/cmd/gosec@latest`)
-- govulncheck (`go install golang.org/x/vuln/cmd/govulncheck@latest`)
-- addlicense (`go install github.com/nokia/addlicense@latest`)
+- [golangci-lint] (e.g. `curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.2`)
+- [gocritic] (e.g. `go install -v github.com/go-critic/go-critic/cmd/gocritic@latest`; you may also need to add `~/go/bin` to your `PATH`)
+- [staticcheck] (e.g. `go install honnef.co/go/tools/cmd/staticcheck@latest`)
+- [gosec] (e.g. `go install github.com/securego/gosec/v2/cmd/gosec@latest`)
+- [govulncheck] (e.g. `go install golang.org/x/vuln/cmd/govulncheck@latest`)
+- [addlicense] (e.g. `go install github.com/nokia/addlicense@latest`)
 
 ### Build & Install
 


### PR DESCRIPTION
This pull request makes a few minor changes:

1) A new install target, `install-dangerously` has been added to the `makefile` to pair with the existing build target `build-dangerously`. This allows users to run local code without performing `make check`:

```shell
make build-dangerously
make install-dangerously
```

2) Refactored installation of shell completion into make target. The new `make completion` target will tell the user how to manage shell completion by running `ivcap completion <SHELL> -h` for the host shell (bash, zsh, fish or powershell).

3) Update README.md for `dangerous` build and install targets. Links to install instructions for code prerequisites included.