### PR TITLE
URL with Trailing Slash Causes 404 Error When Creating Context

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -64,10 +65,10 @@ var createContextCmd = &cobra.Command{
 	Use:   "create ctxtName https://ivcap.net",
 	Short: "Create a new context",
 	Args:  cobra.ExactArgs(2),
-	//Aliases: []string{"create"},
+	// Aliases: []string{"create"},
 	Run: func(_ *cobra.Command, args []string) {
 		ctxtName = args[0]
-		ctxtUrl := args[1]
+		ctxtUrl := strings.TrimRight(args[1], "/")
 		url, err := url.ParseRequestURI(ctxtUrl)
 		if err != nil || url.Host == "" {
 			cobra.CheckErr(fmt.Sprintf("url '%s' is not a valid URL", ctxtUrl))
@@ -87,7 +88,7 @@ var createContextCmd = &cobra.Command{
 var listContextCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all context",
-	//Aliases: []string{"get-context", "list"},
+	// Aliases: []string{"get-context", "list"},
 	Run: func(_ *cobra.Command, _ []string) {
 		config, _ := ReadConfigFile(true)
 		if config != nil {

--- a/pkg/adapter/url_parser.go
+++ b/pkg/adapter/url_parser.go
@@ -1,0 +1,30 @@
+package adapter
+
+import (
+	"fmt"
+	neturl "net/url"
+)
+
+func parseURL(endpoint string, connCtxt *ConnectionCtxt) (*neturl.URL, error) {
+	// Try to parse the endpoint as an absolute URL
+	parsedURL, err := neturl.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse endpoint: %w", err)
+	}
+
+	// If the endpoint is not absolute, resolve it against the base URL
+	if !parsedURL.IsAbs() {
+		base, err := neturl.Parse(connCtxt.URL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse base URL: %w", err)
+		}
+		parsedURL = base.ResolveReference(parsedURL)
+	}
+
+	// Check if the scheme is http
+	if parsedURL.Scheme != "http" {
+		return nil, fmt.Errorf("invalid scheme: %s", parsedURL.Scheme)
+	}
+
+	return parsedURL, nil
+}

--- a/pkg/adapter/url_parser.go
+++ b/pkg/adapter/url_parser.go
@@ -22,7 +22,7 @@ func parseURL(endpoint string, connCtxt *ConnectionCtxt) (*neturl.URL, error) {
 	}
 
 	// Check if the scheme is http
-	if parsedURL.Scheme != "http" {
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
 		return nil, fmt.Errorf("invalid scheme: %s", parsedURL.Scheme)
 	}
 

--- a/pkg/adapter/url_parser_test.go
+++ b/pkg/adapter/url_parser_test.go
@@ -1,0 +1,88 @@
+package adapter
+
+import (
+	neturl "net/url"
+	"testing"
+)
+
+func TestParseURL(t *testing.T) {
+	tests := []struct {
+		name      string
+		endpoint  string
+		connCtxt  *ConnectionCtxt
+		parsedURL *neturl.URL
+		wantErr   bool
+	}{
+		{
+			name:     "Valid URL defined in the endpoint",
+			endpoint: "http://example.com/path",
+			connCtxt: &ConnectionCtxt{URL: ""},
+			parsedURL: &neturl.URL{
+				Scheme: "http",
+				Host:   "example.com",
+				Path:   "/path",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "Invalid URL defined in the endpoint",
+			endpoint:  "httpexample.com",
+			connCtxt:  &ConnectionCtxt{URL: ""},
+			parsedURL: nil,
+			wantErr:   true,
+		},
+		{
+			name:     "Undefined URL",
+			endpoint: "invalid_url",
+			connCtxt: &ConnectionCtxt{URL: ""},
+			wantErr:  true,
+		},
+		{
+			name:     "Valid URL with defined endpoint",
+			endpoint: "/path",
+			connCtxt: &ConnectionCtxt{URL: "http://example.com"},
+			parsedURL: &neturl.URL{
+				Scheme: "http",
+				Host:   "example.com",
+				Path:   "/path",
+			},
+			wantErr: false,
+		},
+		{
+			name:     "Valid URL with undefined endpoint",
+			endpoint: "",
+			connCtxt: &ConnectionCtxt{URL: "http://example.com"},
+			parsedURL: &neturl.URL{
+				Scheme: "http",
+				Host:   "example.com",
+				Path:   "",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "Valid URL with invalid endpoint",
+			endpoint:  "/%zz",
+			connCtxt:  &ConnectionCtxt{URL: "http://example.com"},
+			parsedURL: nil,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsedURL, err := parseURL(tt.endpoint, tt.connCtxt)
+			if tt.wantErr && err == nil {
+				t.Errorf("parseURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("parseURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.parsedURL != nil && parsedURL == nil {
+				t.Errorf("parseURL() parsedURL = %v, want %v", parsedURL, tt.parsedURL)
+			}
+			if tt.parsedURL != nil && parsedURL != nil && parsedURL.String() != tt.parsedURL.String() {
+				t.Errorf("parseURL() parsedURL = %v, want %v", parsedURL, tt.parsedURL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pulling request intends to address issue #38.

I have addressed it in two areas of the cli:
- In 94e638abeefab587ffc81c588b1bf31d51bd85fa and 099be798558ea7fada67a506adc154276216bb9d I have refactored  `pkg/adapter/adapter.go` to make use of "net/url" functionality instead of doing string manipulation. In the process, I pulled out the URL parsing code and wrapped it up in unit tests. This change seems to have fixed the bug regardless of whether the end-user submits a URL with a forward slash or not.
- In c04958b5baa9a8240172a8603f8af68eccb14e6a I have modified the createContextCmd function to trim any trailing
slashes from the context URL, ensuring that the URL is stored in a consistent format regardless of how it was entered by the user.