### PR TITLE
Add flake.nix and .envrc for using nix and direnv to develop and build.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ dist
 .github-release-token
 .vscode/
 __debug_bin
-data/
+data/.direnv/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1717602782,
+        "narHash": "sha256-pL9jeus5QpX5R+9rsp3hhZ+uplVHscNJh8n8VpqscM0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e8057b67ebf307f01bdcc8fba94d94f75039d1f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,53 @@
+{
+  description = "IVCAP Command Line Interface (CLI)";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "i686-linux" "aarch64-linux" "aarch64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: f system);
+    in {
+        overlay = final: prev: {
+          ivcap-cli = with final; stdenv.mkDerivation {
+            name = "ivcap-cli";
+            src = self;
+            buildPhase = "make";
+            installPhase = "make install";
+            buildInputs = with pkgs; [
+              go
+              addlicense
+              golangci-lint
+              go-critic
+              go-tools
+              gosec
+              govulncheck
+            ];
+          };
+        };
+
+        defaultPackage = forAllSystems(system: (import nixpkgs {
+          inherit system;
+          overlays = [ self.overlay ];
+        }).ivcap-cli);
+
+        devShells = forAllSystems(system:
+          let pkgs = nixpkgs.legacyPackages.${system};
+          in {
+            default = pkgs.mkShell {
+              buildInputs = with pkgs; [
+                go
+                addlicense
+                golangci-lint
+                go-critic
+                go-tools
+                gosec
+                govulncheck
+              ];
+            };
+          });
+        };
+}


### PR DESCRIPTION
This adds a 'nix flake', being a file which precisely which packages to install on a system to be able to build ivcap-cli. If the developer has nix installed, with the flakes feature enabled, then they can run `nix develop` to get a shell in which they can run `make` and `make install`.

It also adds a .envrc, which works with direnv, and tells it that whenever the developer changes into this directory their shell should automatically run `nix develop` to give them the required build tools.

This is useful for me; maybe for others? And shouldn't get in anyone's way, except to add a few files in the top-level directory.