### PR TITLE
updating to newer IVCAP API version as well as go1.22.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build-dangerously:
 	${GOPRIVATE_ENV_CMD} go mod tidy
 	go build -ldflags ${LD_FLAGS} ivcap.go
 
-install-dangerously:
+install-dangerously: build-dangerously
 	go install -ldflags ${LD_FLAGS} ivcap.go
 
 build-docs:

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/ivcap-works/ivcap-cli
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/MicahParks/keyfunc v1.5.3
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/dustin/go-humanize v1.0.1
 	github.com/golang-jwt/jwt/v4 v4.5.0
-	github.com/ivcap-works/ivcap-core-api v0.35.3
+	github.com/ivcap-works/ivcap-core-api v0.40.3
 	github.com/jedib0t/go-pretty/v6 v6.5.8
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/schollz/progressbar/v3 v3.14.2

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/ivcap-works/ivcap-core-api v0.35.3 h1:RuajWqoF1x6pilb8ZY7Drd2v9SkeOG87/FIaNH7og+U=
-github.com/ivcap-works/ivcap-core-api v0.35.3/go.mod h1:NbggH/FvNC8IPfHUaDBryKqfB5JPswoC0itpRUVqq6o=
+github.com/ivcap-works/ivcap-core-api v0.40.3 h1:ITdfxWSA4rBsM2lurwvHtXk33ruTV8OgQ4PYsqjBJDw=
+github.com/ivcap-works/ivcap-core-api v0.40.3/go.mod h1:NbggH/FvNC8IPfHUaDBryKqfB5JPswoC0itpRUVqq6o=
 github.com/jedib0t/go-pretty/v6 v6.5.8 h1:8BCzJdSvUbaDuRba4YVh+SKMGcAAKdkcF3SVFbrHAtQ=
 github.com/jedib0t/go-pretty/v6 v6.5.8/go.mod h1:zbn98qrYlh95FIhwwsbIip0LYpwSG8SUOScs+v9/t0E=
 github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213 h1:qGQQKEcAR99REcMpsXCp3lJ03zYT1PkRd3kQGPn9GVg=


### PR DESCRIPTION
The schema of the `aspect create` return struct has changed which led to a nil pointer exception when uploading artifacts.

Also upgraded to using go 1.22.5 to avoid a security error which prevented building