### PR TITLE
fix the hardcode auth audience

### DIFF
--- a/.github/workflows/go-critic.yml
+++ b/.github/workflows/go-critic.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.2
+          go-version: 1.22.5
       - name: Install go-critic
         run: go install -v github.com/go-critic/go-critic/cmd/gocritic@latest
       - name: Run gocritic

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.2
+          go-version: 1.22.5
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
       - name: Run golangci-lint

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.2
+          go-version: 1.22.5
       - name: Install Gosec
         run: go install github.com/securego/gosec/v2/cmd/gosec@latest
       - name: Run Gosec

--- a/.github/workflows/govet.yml
+++ b/.github/workflows/govet.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22.2
+          - 1.22.5
         platform:
           - ubuntu-latest
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.2
+          go-version: 1.22.5
       - name: Install Govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run Govulncheck

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.2
+          go-version: 1.22.5
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@latest
       - name: Run staticcheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22.2
+          - 1.22.5
         platform:
           - ubuntu-latest
     runs-on: ${{ matrix.platform }}

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ You will need the following installed:
 [govulncheck]:   https://go.googlesource.com/vuln
 [addlicense]:    https://github.com/nokia/addlicense?tab=readme-ov-file#install-as-a-go-program
 
-- go version >= 1.22.2 (e.g. `snap install go --classic`)
+- go version >= 1.22.5 (e.g. `snap install go --classic`)
 - [golangci-lint] (e.g. `curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.57.2`)
 - [gocritic] (e.g. `go install -v github.com/go-critic/go-critic/cmd/gocritic@latest`; you may also need to add `~/go/bin` to your `PATH`)
 - [staticcheck] (e.g. `go install honnef.co/go/tools/cmd/staticcheck@latest`)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/MicahParks/keyfunc"
@@ -393,9 +394,7 @@ func login(_ *cobra.Command, args []string) {
 	// offline_access is required for the refresh tokens to be sent through
 	authProvider.scopes = "openid profile email offline_access"
 	authProvider.grantType = "urn:ietf:params:oauth:grant-type:device_code"
-	// TODO: Shouldn't that come from the server?
-	authProvider.audience = "https://api.ivcap.net/"
-
+	authProvider.audience = strings.TrimSuffix(ctxt.URL, "/") + "/"
 	// First request a device code for this command line tool
 	deviceCode := requestDeviceCode(authProvider)
 

--- a/pkg/adapter/payload.go
+++ b/pkg/adapter/payload.go
@@ -193,7 +193,7 @@ func (p *payload) AsBytes() []byte {
 }
 
 func (p *payload) IsEmpty() bool {
-	return p.body == nil || len(p.body) == 0
+	return len(p.body) == 0
 }
 
 func (p *payload) Header(key string) string {


### PR DESCRIPTION
## Description
The issue is related to when switch domain names from `develop.ivcap.net` to `api.ivcap.net` or `api.sigma8.app` 
Hardcoded to `api.ivcap.net` does not work, when `ivcap-core` checking the auth token.

