### PR TITLE
Refactor AuthProvider to use configurable audience from authinfo.yaml

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -397,7 +397,6 @@ func login(_ *cobra.Command, args []string) {
 	// offline_access is required for the refresh tokens to be sent through
 	authProvider.scopes = "openid profile email offline_access"
 	authProvider.grantType = "urn:ietf:params:oauth:grant-type:device_code"
-	// authProvider.audience = strings.TrimSuffix(ctxt.URL, "/") + "/"
 	// First request a device code for this command line tool
 	deviceCode := requestDeviceCode(authProvider)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,8 +36,10 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-const ENV_PREFIX = "IVCAP"
-const URN_PREFIX = "ivcap"
+const (
+	ENV_PREFIX = "IVCAP"
+	URN_PREFIX = "ivcap"
+)
 
 const RELEASE_CHECK_URL = "https://github.com/ivcap-works/ivcap-cli/releases/latest"
 
@@ -270,14 +272,15 @@ func safeTruncString(in *string) (out string) {
 }
 
 func safeBytes(n *int64) string {
-	if n != nil {
-		if *n <= 0 {
-			return "unknown"
-		}
-		return humanize.Bytes(uint64(*n))
-	} else {
+	if n == nil {
 		return "???"
 	}
+	if *n <= 0 {
+		return "unknown"
+	}
+	// Safe to convert to uint64 here because we've checked for negative values
+	// #nosec G115
+	return humanize.Bytes(uint64(*n))
 }
 
 func payloadFromFile(fileName string, inputFormat string) (pyld adpt.Payload, err error) {


### PR DESCRIPTION
Changes include:
1. **Update Audience Handling in `AuthProvider`:**
   - The `AuthProvider` struct now includes `Audience` as a field derived from `authinfo.yaml`.
   - Removed the string manipulation logic that derived the audience from `ctxt.URL`. Instead, the audience is now directly set from the `authinfo.yaml` file.
   - Added a validation step to check if the audience is properly set in `authinfo.yaml` before proceeding with authentication.
   - The `requestDeviceCode` function has been updated to use the new `Audience` field for device code requests.

2. **Refactor `safeBytes` function in `root.go`:**
   - Simplified the logic of the `safeBytes` function.
   - Added a comment to ignore a `gosec` warning related to the conversion from `int64` to `uint64`, ensuring the function is safe by checking for negative values before conversion.

#### Motivation:
While trying to log in to the local `ivcap` instance using the CLI tool, I discovered that the audience was incorrectly being set to `http://ivcap.kube` instead of the expected `http://ivcap.minikube` as defined in `authinfo.yaml`. The previous implementation relied on the `ctxt.URL` value, causing the mismatch. This PR resolves that issue by ensuring the audience is derived from the `authinfo.yaml` file, providing more flexibility and reducing configuration issues during local deployment.