### PR TITLE
brought local artifact metafile in sync with python client library

### DIFF
--- a/.github/workflows/go-critic.yml
+++ b/.github/workflows/go-critic.yml
@@ -21,11 +21,11 @@ jobs:
         uses: actions/checkout@v3
       - name: Granting private modules access
         run: |
-            git config --global url."ssh://git@github.com/".insteadOf "https://github.com/"
+          git config --global url."ssh://git@github.com/".insteadOf "https://github.com/"
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.5
+          go-version: 1.23.1
       - name: Install go-critic
         run: go install -v github.com/go-critic/go-critic/cmd/gocritic@latest
       - name: Run gocritic

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.5
+          go-version: 1.23.1
       - name: Install golangci-lint
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
       - name: Run golangci-lint

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.5
+          go-version: 1.23.1
       - name: Install Gosec
         run: go install github.com/securego/gosec/v2/cmd/gosec@latest
       - name: Run Gosec

--- a/.github/workflows/govet.yml
+++ b/.github/workflows/govet.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22.5
+          - 1.23.1
         platform:
           - ubuntu-latest
     runs-on: ${{ matrix.platform }}
@@ -28,6 +28,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '${{ matrix.go-version }}'
+          go-version: "${{ matrix.go-version }}"
       - name: Run go vet
         run: go vet -v ./...

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.5
+          go-version: 1.23.1
       - name: Install Govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run Govulncheck

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.22.5
+          go-version: 1.23.1
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@latest
       - name: Run staticcheck

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.22.5
+          - 1.23.1
         platform:
           - ubuntu-latest
     runs-on: ${{ matrix.platform }}
@@ -28,7 +28,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: '${{ matrix.go-version }}'
+          go-version: "${{ matrix.go-version }}"
       - name: Run test
         run: go test -v ./...
       - name: Run test -race

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 .vscode/
 __debug_bin
 data/.direnv/
+data/

--- a/cmd/artifact.go
+++ b/cmd/artifact.go
@@ -17,6 +17,8 @@ package cmd
 import (
 	"bufio"
 	"context"
+
+	"crypto/md5" // #nosec G501
 	"fmt"
 	"io"
 	"path/filepath"
@@ -355,16 +357,25 @@ func uploadArtifact(
 ) (artifactID string) {
 	var reader io.Reader
 	var size int64
+
+	fileHash := getFileHash(fileName)
 	metaFile, metaExists := getArtifactMetaFileFor(fileName)
 	if !force && metaFile != nil && metaExists {
-		artifactID = getArtifactIdFromMeta(*metaFile)
-		msg := fmt.Sprintf("File '%s' already uploaded as '%s (%s)'. Use '--force' to create a new artifact",
-			fileName, artifactID, MakeHistory(&artifactID))
-		cobra.CheckErr(msg)
-		return
+		if aidP := getArtifactIdFromMeta(*metaFile, fileHash); aidP != nil {
+			artifactID = *aidP
+			if silent {
+				fmt.Printf("%s\n", artifactID)
+			} else {
+				fmt.Printf("File '%s' is already uploaded as '%s (%s)'.\nUse '--force' to create a new artifact\n",
+					fileName, artifactID, MakeHistory(&artifactID))
+			}
+			os.Exit(0)
+			return
+		}
 	}
 	reader, contentType, size = getReader(fileName, contentType)
-	logger.Debug("create artifact", log.String("content-type", contentType), log.String("file", fileName))
+	logger.Debug("create artifact", log.String("content-type", contentType), log.String("file", fileName),
+		log.Int64("size", size))
 	if name == "" && fileName != "-" {
 		name = filepath.Base(fileName)
 	}
@@ -399,7 +410,8 @@ func uploadArtifact(
 		fmt.Printf("%s\n", artifactID)
 	}
 	if metaFile != nil {
-		err = os.WriteFile(*metaFile, []byte(artifactID), 0644) // #nosec G306 -- only includes the artifact ID
+		m := fmt.Sprintf("%s|%s", fileHash, artifactID)
+		err = os.WriteFile(*metaFile, []byte(m), 0644) // #nosec G306 -- only includes the artifact ID
 		if err != nil {
 			cobra.CheckErr(fmt.Sprintf("saving information to metafile '%s' failed - %v", *metaFile, err))
 		}
@@ -613,18 +625,46 @@ func getArtifactMetaFileFor(fileName string) (fnp *string, fileExists bool) {
 		cobra.CheckErr(fmt.Sprintf("Can't obtain absolute path of '%s' - %v", fileName, err))
 	}
 	fdir := filepath.Dir(afn)
-	fn := filepath.Join(fdir, fmt.Sprintf(".%s", filepath.Base(afn)))
+	fn := filepath.Join(fdir, fmt.Sprintf(".ivcap-%s.txt", filepath.Base(afn)))
+
 	if _, err = os.Stat(fn); err == nil {
 		fileExists = true
 	}
+	logger.Debug("checking for local artifact meta info", log.String("path", fn), log.Bool("exist?", fileExists))
 	return &fn, fileExists
 }
 
-func getArtifactIdFromMeta(fileName string) string {
+func getArtifactIdFromMeta(fileName string, fileHash string) *string {
 	b, err := os.ReadFile(filepath.Clean(fileName))
-	if err == nil {
-		return string(b)
-	} else {
-		return ""
+	if err != nil {
+		return nil
 	}
+	c := string(b)
+	sa := strings.Split(c, "|")
+	if len(sa) != 2 {
+		return nil
+	}
+	if sa[0] != fileHash {
+		return nil
+	}
+	aid := strings.Trim(sa[1], "\n")
+	return &aid
+}
+
+func getFileHash(fileName string) string {
+	file, err := os.Open(fileName) // #nosec G304
+	if err != nil {
+		cobra.CheckErr(fmt.Sprintf("while opening data file '%s' - %v", fileName, err))
+		// never get here as cobra.CheckErr calls os.Exit
+	}
+	defer file.Close()
+
+	hash := md5.New() // #nosec G401
+	if _, err = io.Copy(hash, file); err != nil {
+		cobra.CheckErr(fmt.Sprintf("while reading data file '%s' - %v", fileName, err))
+		// never get here as cobra.CheckErr calls os.Exit
+	}
+	sum := hash.Sum(nil)
+	return fmt.Sprintf("%x", sum)
+
 }

--- a/cmd/collection.go
+++ b/cmd/collection.go
@@ -145,11 +145,13 @@ var (
 					continue
 				}
 				fn := filepath.Join(collectionDir, name)
+				fileHash := getFileHash(fn)
 				if mfn, exists := getArtifactMetaFileFor(fn); exists {
-					aid := getArtifactIdFromMeta(*mfn)
-					addAID(name, aid)
-					fmt.Printf("... Skipping '%s', already uploaded as '%s'\n", name, aid)
-					continue
+					if aid := getArtifactIdFromMeta(*mfn, fileHash); aid != nil {
+						addAID(name, *aid)
+						fmt.Printf("... Skipping '%s', already uploaded as '%s'\n", name, *aid)
+						continue
+					}
 				}
 				addAID(name, uploadArtifact(fn, false, ""))
 			}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ivcap-works/ivcap-cli
 
-go 1.22.5
+go 1.23.1
 
 require (
 	github.com/MicahParks/keyfunc v1.5.3


### PR DESCRIPTION
When creating an artifact we were also writing a 'dot' file into the same directory as the file to be uploaded.

The same functionality was implemented in the python ivcap client sdk, however differently, and a bit more advanced.
Specifically the python sdk also added an MD5 hash of the file into the dot file to capture any local changes. It also had a slightly different naming schema, adding a `.ivcap-...` prefix to avoid any potentially clashes with other tools.

This PR brings the cli tool in sync with the python SDK.

It also aligns the output of `ivcap --silent artifact create -f` which now simply returns the artifact ID for both cases, the newly created one and the already-uploaded one.

Also upgraded the go version to 1.23.1 to get in sync with the current version used for the core