### PR TITLE
fix(queue_test): revert queue schema

### DIFF
--- a/cmd/queue_test.go
+++ b/cmd/queue_test.go
@@ -66,7 +66,7 @@ func testEnqueue(t *testing.T) {
 		t.Skip("access token not found, login to run unit test...")
 	}
 
-	schema := "urn:test:schema:temp-measurement.1"
+	schema := "urn:ivcap:schema:queue:message.1"
 	payload := `{
     "temperature": "21",
     "location": "Buoy101",


### PR DESCRIPTION
Reverted the schema in the testEnqueue function back to the correct value of "urn:ivcap:schema:queue:message.1".

Commit da0513e changed the schema to "urn:test:schema:temp-measurement.1" and this was breaking the tests.