### PR TITLE
Send upgrade message to standard error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -381,9 +381,9 @@ func checkForUpdates(currentVersion string) {
 			latest := strings.TrimPrefix(p[len(p)-1], "v")
 			current := strings.TrimPrefix(strings.Split(currentVersion, "|")[0], "v")
 			if current != latest {
-				fmt.Printf("\n>>>   A newer version 'v%s' is available. Please consider upgrading from 'v%s'", latest, current)
-				fmt.Printf("\n>>>     It is available at %s", RELEASE_CHECK_URL)
-				fmt.Printf("\n>>>     Or via 'brew upgrade ivcap'\n\n")
+				fmt.Fprintf(os.Stderr, "\n>>>   A newer version 'v%s' is available. Please consider upgrading from 'v%s'", latest, current)
+				fmt.Fprintf(os.Stderr, "\n>>>     It is available at %s", RELEASE_CHECK_URL)
+				fmt.Fprintf(os.Stderr, "\n>>>     Or via 'brew upgrade ivcap'\n\n")
 			}
 		}
 	}


### PR DESCRIPTION
so as not to pollute std out, so it can still be parsed.

https://github.com/ivcap-works/ivcap-cli/issues/69

