### PR TITLE
ivcap pkg: fix push output

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.24.11
+          go-version: 1.24.12
       - name: Install Govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run Govulncheck

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	sdk "github.com/ivcap-works/ivcap-cli/pkg"
 	"github.com/spf13/cobra"
@@ -73,8 +74,14 @@ var (
 		Long:  `Before/After creating service, push the service package to a docker registry that the service can reference.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			ivcapContext := GetActiveContext()
+			parts := strings.Split(ivcapContext.AccountID, ":")
+			if len(parts) < 2 {
+				return fmt.Errorf("invalid format of context accountID: %s", ivcapContext.AccountID)
+			}
+			accountID := parts[len(parts)-1]
 			srcPackageTag := args[0]
-			_, err = sdk.PushPackage(context.Background(), srcPackageTag, forcePush, localImage, *CreateAdapter(true), logger)
+			_, err = sdk.PushPackage(context.Background(), accountID, srcPackageTag, forcePush, localImage, *CreateAdapter(true), logger)
 			if err != nil {
 				return err
 			}

--- a/pkg/package.go
+++ b/pkg/package.go
@@ -65,7 +65,7 @@ func ListPackages(ctxt context.Context, tag string, adpt *adapter.Adapter, logge
 	return &body, nil
 }
 
-func PushPackage(ctx context.Context, srcTagName string, forcePush, localImage bool, adpt adapter.Adapter, logger *log.Logger) (*api.PushResponseBody, error) {
+func PushPackage(ctx context.Context, accountID string, srcTagName string, forcePush, localImage bool, adpt adapter.Adapter, logger *log.Logger) (*api.PushResponseBody, error) {
 	srcTag, err := name.NewTag(srcTagName, name.WeakValidation, name.WithDefaultRegistry("local"))
 	if err != nil {
 		return nil, fmt.Errorf("invalid src tag format: %w", err)
@@ -108,7 +108,7 @@ func PushPackage(ctx context.Context, srcTagName string, forcePush, localImage b
 	if err = checkPushResponse(pushResp, srcTagName); err != nil {
 		fmt.Printf("\033[2K\r %s push failed, error: %s\n", srcTagName, err.Error())
 	} else {
-		fmt.Printf("\033[2K\r %s pushed\n", srcTagName)
+		fmt.Printf("\033[2K\r %s/%s pushed\n", accountID, srcTagName)
 	}
 
 	return &api.PushResponseBody{


### PR DESCRIPTION
### Description

Fix the ivcap push output, since poetry plugin is expecting the format `account-id/repo:tag`