### PR TITLE
ivcap pkg list: fix the ivcap pkg list with exact 1 arg required

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.24.11
+          go-version: 1.24.13
       - name: Install Govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run Govulncheck

--- a/cmd/package.go
+++ b/cmd/package.go
@@ -43,11 +43,11 @@ var (
 	}
 
 	listPackageCmd = &cobra.Command{
-		Use:     "list [tag]",
+		Use:     "list image[:tag]",
 		Aliases: []string{"ls"},
 		Short:   "list service packages",
-		Long:    `List the service packages under current account, or other accounts if you know the account id.`,
-		Args:    cobra.RangeArgs(0, 1),
+		Long:    `List the service packages by image or image:tag under current account, image can have other account-id as prefix, if you have the permission to read.`,
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			ctxt := context.Background()
 			var tag string


### PR DESCRIPTION
### Description
`ivcap pkg list` does not support full repo scan anymore. 

So update the cmd with param request accordingly.